### PR TITLE
Not twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,10 @@ Building a real deployed full-stack application, backed by Data Science
 
 *Note* - assignments this week are all steps in a larger week-long project. They
 are to be worked on in a repo you make with your own account, as instructed in
-the first day. You can still fork this repo for offline reference.
+the first day. You should still fork this repo, and open a PR where you add a
+`work_notes.md` file that includes a link to your project repo. You should then
+update `work_notes.md` each day with the following:
+
+- What went well (in the context of working on the assignment) today?
+- What was particularly interesting or surprising about the topic(s) today?
+- What was the most challenging part of the work today, and why?

--- a/README.md
+++ b/README.md
@@ -4,10 +4,4 @@ Building a real deployed full-stack application, backed by Data Science
 
 *Note* - assignments this week are all steps in a larger week-long project. They
 are to be worked on in a repo you make with your own account, as instructed in
-the first day. You should still fork this repo, and open a PR where you add a
-`work_notes.md` file that includes a link to your project repo. You should then
-update `work_notes.md` each day with the following:
-
-- What went well (in the context of working on the assignment) today?
-- What was particularly interesting or surprising about the topic(s) today?
-- What was the most challenging part of the work today, and why?
+the first day. You can still fork this repo for offline reference.

--- a/module1-web-application-development-with-flask/guided-project.md
+++ b/module1-web-application-development-with-flask/guided-project.md
@@ -105,7 +105,7 @@ and
 
 `flask run`
 
-You should see a message about your app running on a development server along with the a messaget that the app is running on a url:
+You should see a message about your app running on a development server along with a message that the app is running on a url:
 
 ```bash
  * Running on http://127.0.0.1:5000/
@@ -382,10 +382,10 @@ We'll need to change our home `'/'` route so that it queries the DB for users an
 
 ```python
 @app.route('/')
-    def root():
-        # return page contents
-        users = User.query.all()
-        return render_template('base.html', title="Home", users=users)
+def root():
+    # return page contents
+    users = User.query.all()
+    return render_template('base.html', title="Home", users=users)
 ```
 
 Last of all, we'll add a for loop to our `base.html` file so that new pieces of html get added to the page for each user. Change the `<article> stuff in here</article>` section to look like the following:
@@ -400,4 +400,4 @@ Last of all, we'll add a for loop to our `base.html` file so that new pieces of 
     </article>
 ```
 
-After you've added that for loop restart your app, reset and populate your database and see if you can see database usernames being displayed on the home page. What you're seing there is the result of a full-stack web app that's detecting the route the user is visiting, querying the database, and then inserting the queried data into the HTML that the server is returning to the browser. Pretty Cool!
+After you've added that for loop restart your app, reset and populate your database and see if you can see database usernames being displayed on the home page. What you're seeing there is the result of a full-stack web app that's detecting the route the user is visiting, querying the database, and then inserting the queried data into the HTML that the server is returning to the browser. Pretty Cool!

--- a/module2-consuming-data-from-an-api/README.md
+++ b/module2-consuming-data-from-an-api/README.md
@@ -8,18 +8,10 @@ when starting out, but there are some steps and hoops to get it working.
 
 ## Learning Objectives
 
-- Connect to the Twitter API and query for tweets by various parameters
+- Connect to the NotTwitter API and query for tweets by various parameters
 - Implement a SpaCy NLP model to create embeddings from our tweet text.
 
 ## Before Lecture
-
-Sign up for [Twitter Developer
-access](https://developer.twitter.com/en/apply-for-access) - this requires
-answering various questions about what you will use the API for. Answer
-honestly, mentioning that you are a student and will be developing an
-application that analyzes the textual content of Tweets for comparing different
-Twitter users. Also check out [Tweepy](https://tweepy.readthedocs.io/), a Python
-package that facilitates accessing the Twitter API.
 
 Explore the [SpaCy](https://spacy.io/usage/spacy-101). This service will let you use the [word2vect](https://en.wikipedia.org/wiki/Word2vec) to fitpredictive models such as regression to numerical data. This allows us to work with things data scientist like most - digits - opposed to unstructured words. These numbers are referred to as "embeddings" - the numbers representing the words or phrases from the vocabulary.
 
@@ -38,12 +30,6 @@ See [assignment.md](https://github.com/LambdaSchool/DS-Unit-3-Sprint-3-Productiz
   but powerful - take advantage of it!
 - [postman](https://www.postman.com/downloads/) is an app to let you test both your
   routes and a REST API
-- Go deeper with the Twitter API - use paging (offset by oldest fetched Tweet
-  ID) to pull older Tweets, so you can build a larger set of embedding data for
-  a given user
-- [twitter-scraper](https://github.com/kennethreitz/twitter-scraper) is another
-  approach to getting data from Twitter - no auth required (but Twitter may
-  choose to try to break it)
 - Make the home page a bit more useful - links to pulled users, descriptive
   text, etc.
 - Make your app look nicer - the earlier mentioned [Picnic
@@ -57,19 +43,5 @@ See [assignment.md](https://github.com/LambdaSchool/DS-Unit-3-Sprint-3-Productiz
   what information from the API might be fun to play with and store in our database.
   
   
-## Twitter Developer Account Alternative
-If you are having trouble getting access to a Twitter developer account check out [this API](https://lambda-ds-twit-assist.herokuapp.com/) that
-will allow you to make HTTP GET request to a third party API to get back information about a specific user. 
-
-All you need to do is utilize the `requests` library and make a get request to the following url and specifiy the user within the endpoint.
-```python
-https://lambda-ds-twit-assist.herokuapp.com/user/<twitter_handle>
-```
-Then you need to populate the values and ids into the database with SQLAlchemy. An example of a request may look like the following:
-```python
-import ast # for unpacking the literal string object 
-import requests
-
-status = requests.get("https://lambda-ds-twit-assist.herokuapp.com/user/elonmusk")
-elon = ast.literal_eval(status.text)
-```
+## Twitter Developer Account
+[Note about NotTwitter & NotTweepy]

--- a/module2-consuming-data-from-an-api/README.md
+++ b/module2-consuming-data-from-an-api/README.md
@@ -44,4 +44,35 @@ See [assignment.md](https://github.com/LambdaSchool/DS-Unit-3-Sprint-3-Productiz
   
   
 ## Twitter Developer Account
-[Note about NotTwitter & NotTweepy]
+- Twitter Dev Account and API keys are no longer required.
+- Anywhere that tweepy is mentioned use not_tweepy instead.
+
+- When you see this:
+```python
+import tweepy
+```
+- Do this instead:
+```python
+import not_tweepy as tweepy
+```
+
+Twitter is changing their API policies and tweepy is going offline very soon. The dev team at Bloom Tech implemented a Twitter-API-like clone and an API interface library to bridge the gap. We named the Twitter API "NotTwitter" and the library "NotTweepy". To install NotTweepy simply copy the folder `not_tweepy` into your local repo at the root level of your project.
+
+- Project
+  - twitoff
+  - not_tweepy
+
+NotTwitter has been prepopulated with tweets from the following users:
+- calebhicks
+- elonmusk
+- rrherr
+- SteveMartinToGo
+- alyankovic
+- NASA
+- jkhowland
+- Austen
+- common_squirrel
+- KenJennings
+- ConanOBrien
+- big_ben_clock
+- IAM_SHAKESPEARE

--- a/module2-consuming-data-from-an-api/guided-project.md
+++ b/module2-consuming-data-from-an-api/guided-project.md
@@ -31,13 +31,13 @@ Today we're going to knock out the steps 1, 2, and 3 of what our app does.
 
 Before we can make requests to the Twitter API from our app we need to install a few new python packages
 
-- `tweepy` - Makes it easy to query the twitter API with Python.
+- `not_tweepy` - Makes it easy to query the NotTwitter API with Python. To install this package, copy the folder `not_tweepy` to the root of your local project folder. This package is a replacement for tweepy.
 - `spacy` - A whole bunch of NLP tools, but the main one that we'll be using translates text into a numeric representation called "word embeddings."
 - `python-dotenv` - Reads key-value pairs from a `.env` file and sets them as environment variables within our app.
 
 From the command line working from the root of your project folder `twitoff-DS##` run the command:
 
-`pipenv install tweepy spacy python-dotenv`
+`pipenv install spacy python-dotenv`
 
 Then feel free to start up your virtual environment
 
@@ -85,17 +85,18 @@ TWITTER_API_KEY_SECRET=ZMSUwwVVf9HvnS7u1fPwNCkyvfDEHwsbD1XCLgntZdAlA
 ENV=development
 DATABASE_URI=sqlite:///db.sqlite3
 FLASK_APP=twitoff
+NOT_TWITTER_URL=https://not-twitter.herokuapp.com
 ```
 
-Notice how we don't put the values on the right side inside of quotation marks to turn them into strings? It's not necessary to store these variables as strings because this isn't a `.py` file.
+Notice how we don't put the values inside of quotation marks to turn them into strings? It's not necessary to store these variables as strings because this isn't a `.py` file.
 
 Saving our Flask app's name as an environment variable makes it easier to launch the Flask python REPL. We can now start that REPL by just using the command `flask shell`.
 
-In order for your environment variables to take effect, you'll need to close your command line editor and reopen it. So go ahead and shut down your virtual environment, close the terminal (or git bash) and then reopen it and restart your virtual environment.
+In some situations, on some systems, in order for your environment variables to take effect, you'll need to close your command line editor and reopen it. So go ahead and shut down your virtual environment, close the terminal (or git bash) and then reopen it and restart your virtual environment. This is not typically required on Linux or Mac.
 
-## Get tweets from the twitter API and add them to our database
+## Get tweets from the NotTwitter API and add them to our database
 
-Let's see if we can get some tweets from the twitter API using our new credentials by running some code in the Python REPL.
+Let's see if we can get some not_tweets by running some code in the Python REPL.
 
 Start the REPL.
 
@@ -105,17 +106,17 @@ Import the function that we'll use to retrieve our environment varaibles from th
 
 `>>> from os import getenv`
 
-Retrieve our our API Key and API Secret and save them to variables within our REPL.
+Retrieve our API Key and API Secret and save them to variables within our REPL.
 
 `>>> key = os.getenv('TWITTER_API_KEY')`
 
 `>>> secret = os.getenv('TWITTER_API_KEY_SECRET')`
 
-Import tweepy so that we can use it to connect to the Twitter API.
+Import not_tweepy so that we can use it to connect to the NotTwitter API.
 
-`>>> import tweepy`
+`>>> import not_tweepy as tweepy`
 
-Authenticate with the twitter API
+Authenticate
 
 `>>> auth = tweepy.OAuthHandler(key, secret)`
 
@@ -123,11 +124,11 @@ Connect to the API using our authenticated session
 
 `>>> twitter = tweepy.API(auth)`
 
-Create a user (specified by their twitter handle) that we can query the API for.
+Declare a user that we can query the API for.
 
 `>>> user = 'elonmusk'`
 
-Get a bunch of info related to the 'elonmusk' twitter account.
+Get a bunch of info related to the 'elonmusk' account.
 
 `>>> twitter_user = twitter.get_user(screen_name=user)`
 
@@ -139,13 +140,9 @@ Look at the `id` of the twitter user
 
 `>>> twitter_user.id`
 
-See when the account was first created
-
-`>>> twitter_user.created_at`
-
 Get the most recent tweets pertaining to this user
 
-`>>> tweets = twitter_user.timeline(count=200, exclude_replies=True, include_rts=False, tweet_mode='extended')`
+`>>> tweets = twitter_user.timeline()`
 
 Grab the most recent tweet
 
@@ -155,25 +152,15 @@ Look at the text of elon musk's most recent tweet
 
 `>>> tweet1.full_text`
 
-Look at the username of the user who tweeted it.
-
-`>>> tweet1.user.name`
-
-Look at the twitter handle of the user
-
-`>>> tweet1.user.screen_name`
-
-Each tweet has a user object tied to it in a very similar way to how we created a relationship between a user and tweets within our own database.
-
-## Add code to connect to Twitter to our app
+## Add code to connect NotTwitter to our app
 
 Within the inner `twitoff` folder create a new file called `twitter.py`
 
 ```python
-'''Handles connection to Tiwtter API using Tweepy'''
+'''Handles connection to NotTiwtter API using NotTweepy'''
 
 from os import getenv
-import tweepy
+import not_tweepy as tweepy
 import spacy
 from .models import DB, Tweet, User
 
@@ -247,7 +234,7 @@ See how many tweets we successfully added? Why did our code not add 200 tweets?
 
 `>>> len(elonmusk.tweets)`
 
-One you've added a few users, see if they show up on the home page of the app at `localhost:5000` when you run the app.
+Once you've added a few users, see if they show up on the home page of the app at `localhost:5000` when you run the app.
 
 ## Get SpaCy Word Embeddings
 
@@ -401,7 +388,7 @@ def update_all_users():
     usernames = []
     Users = User.query.all()
     for user in Users:
-        usernames.apppend(user.username)
+        usernames.append(user.username)
     
     return usernames
 ```

--- a/module3-adding-data-science-to-a-web-application/guided-project.md
+++ b/module3-adding-data-science-to-a-web-application/guided-project.md
@@ -354,7 +354,7 @@ def create_app():
         try:
             if request.method == 'POST':
                 add_or_update_user(name)
-                message = "User {} Succesfully added!".format(name)
+                message = "User {} Successfully added!".format(name)
 
             tweets = User.query.filter(User.username == name).one().tweets
 

--- a/module4-web-application-deployment/guided-project.md
+++ b/module4-web-application-deployment/guided-project.md
@@ -92,7 +92,7 @@ What's a Procfile?
 
 From the command line, create a `Procfile` in the root of your `twitoff-DS##` project folder.
 
-Next, we'll install a more Heroku-friendly way of starting up our Flask web server. We'llinstall a tool called `gunicorn` and we'll tell Heroku in the `Procfile` how to use gunicorn to start up our app.
+Next, we'll install a more Heroku-friendly way of starting up our Flask web server. We'll install a tool called `gunicorn` and we'll tell Heroku in the `Procfile` how to use gunicorn to start up our app. Please note: gunicorn does not work on Windows. Windows users should skip the installation, but you still need the Procfile specified in the next step after installation.
 
 `pipenv install gunicorn`
 
@@ -100,7 +100,7 @@ After gunicorn has finished installing, open your Procfile and add this line:
 
 `web: gunicorn twitoff:APP -t 120`
 
-This tells Heroku to use `gunicorn` to start up our heroku ap and tells it where it can find the APP variable. We'll also give this a timeont of 120 seconds. because we're working on the free tier Heroku Dyno our app may take a little while to startup. We don't want it to stop trying to startup simply because the Heroku instance isn't very powerful, so this timeout is extra generous to allow plenty of time for Heroku to try and launch the app before erring out with a "gateway timeout" message.
+This tells Heroku to use `gunicorn` to start up our heroku ap and tells it where it can find the APP variable. We'll also give this a timeout of 120 seconds. because we're working on the free tier Heroku Dyno our app may take a little while to startup. We don't want it to stop trying to startup simply because the Heroku instance isn't very powerful, so this timeout is extra generous to allow plenty of time for Heroku to try and launch the app before erring out with a "gateway timeout" message.
 
 Once you've installed `gunicorn` and added a `Procfile` with this line of code in it, be sure to push your changes back to GitHub and then go ahead and try to redeploy the app.
 
@@ -108,7 +108,12 @@ Once you've installed `gunicorn` and added a `Procfile` with this line of code i
 
 When you redeploy the app, you may see new errors in the Heroku Logs, this time you'll see a `H10` error. One thing that can trigger this error message is missing environment variables. Remember that we used our `.gitignore` to make sure that our `.env` file would never be pushed to GitHub? Well Heroku can't see the `.env` file so it doesn't have our Twitter API keys and it doesn't know where to find the database within our app.
 
-Go ahead and add your `TWITTER_API_KEY`, `TWITTER_API_KEY_SECRET` and `DATABSE_URI` environment variables to Heroku. Heroku calls these "Config Vars" and you can add them under the "Settings tab within Heroku.
+Go ahead and add your environment variables to Heroku. Heroku calls these "Config Vars" and you can add them under the "Settings tab within Heroku. The required env vars are as follows:
+
+```
+DATABASE_URL=sqlite:///db.sqlite3
+NOT_TWITTER_URL=https://not-twitter.herokuapp.com
+```
 
 ![Heroku Config Vars](/images/config-vars.png)
 

--- a/not_tweepy/__init__.py
+++ b/not_tweepy/__init__.py
@@ -1,0 +1,3 @@
+from .api import API
+from .auth import OAuth1UserHandler, OAuthHandler
+from .user import User, Tweet

--- a/not_tweepy/api.py
+++ b/not_tweepy/api.py
@@ -1,0 +1,10 @@
+from not_tweepy.user import User
+
+
+class API:
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get_user(self, screen_name: str):
+        return User({"screen_name": screen_name})

--- a/not_tweepy/auth.py
+++ b/not_tweepy/auth.py
@@ -1,0 +1,10 @@
+class OAuth1UserHandler:
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class OAuthHandler:
+
+    def __init__(self, *args, **kwargs):
+        pass

--- a/not_tweepy/user.py
+++ b/not_tweepy/user.py
@@ -1,0 +1,41 @@
+from os import getenv
+from typing import Dict
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+URL = getenv("NOT_TWITTER_URL")
+
+
+class Tweet:
+
+    def __init__(self, data: Dict):
+        self.full_text = ""
+        self.__dict__.update(data)
+
+    def __repr__(self):
+        return "\n".join(f"{k}: {v}" for k, v in vars(self).items())
+
+    def __str__(self):
+        return self.full_text
+
+
+class User:
+
+    def __init__(self, data: Dict):
+        self.screen_name = data.get('screen_name')
+        user_data = requests.get(f"{URL}/user/{self.screen_name}").json()
+        self.__dict__.update(user_data)
+
+    def timeline(self, *args, **kwargs):
+        return [
+            Tweet(tweet)
+            for tweet in requests.get(f"{URL}/read/{self.screen_name}").json()
+        ]
+
+    def __repr__(self):
+        return "\n".join(f"{k}: {v}" for k, v in vars(self).items())
+
+    def __str__(self):
+        return self.screen_name


### PR DESCRIPTION
Twitter is changing their API policies and tweepy is going offline very soon. This PR bridges the gap as a temporary fix for the TwitOff project.

- Adds `not_tweepy` package
- Changes `import tweepy` to `import not_tweepy as tweepy`
- All other code in this project should work as specified in the curriculum
- Learners will no longer need Twitter Dev API keys, altho following the steps with keys will not break anything
- The following users have been pre populated into the NotTwitter API
  - calebhicks
  - elonmusk
  - rrherr
  - SteveMartinToGo
  - alyankovic
  - NASA
  - jkhowland
  - Austen
  - common_squirrel
  - KenJennings
  - ConanOBrien
  - big_ben_clock
  - IAM_SHAKESPEARE
