### PR TITLE
Update guided-project.md

### DIFF
--- a/module2-consuming-data-from-an-api/guided-project.md
+++ b/module2-consuming-data-from-an-api/guided-project.md
@@ -108,9 +108,9 @@ Import the function that we'll use to retrieve our environment varaibles from th
 
 Retrieve our API Key and API Secret and save them to variables within our REPL.
 
-`>>> key = os.getenv('TWITTER_API_KEY')`
+`>>> key = getenv('TWITTER_API_KEY')`
 
-`>>> secret = os.getenv('TWITTER_API_KEY_SECRET')`
+`>>> secret = getenv('TWITTER_API_KEY_SECRET')`
 
 Import not_tweepy so that we can use it to connect to the NotTwitter API.
 


### PR DESCRIPTION
On line 111 and 113 the os is already imported and given substitute of getenv so there is no need of os.getenv() in the next lines.

Changes made:
I deleted os. from 111 and 113